### PR TITLE
MATLAB Color scheme, but dark

### DIFF
--- a/DarkMATLAB.prf
+++ b/DarkMATLAB.prf
@@ -1,0 +1,33 @@
+# DarkMATLAB - MATLAB color scheme
+# Generated with schemer_export v1.4.0, on MATLAB 9.10.0.1739362 (R2021a) Update 5
+# Thu Dec 02 17:30:33 CET 2021
+# To enable this color scheme in MATLAB use schemer_import, available at:
+#     https://github.com/scottclowe/matlab-schemer
+#     https://www.mathworks.com/matlabcentral/fileexchange/53862-matlab-schemer
+ColorsUseSystem=Bfalse
+ColorsUseMLintAutoFixBackground=Btrue
+Editor.VariableHighlighting.Automatic=Btrue
+Editor.NonlocalVariableHighlighting=Btrue
+EditorCodepadHighVisible=Btrue
+EditorCodeBlockDividers=Btrue
+Editorhighlight-caret-row-boolean=Btrue
+EditorRightTextLineVisible=Btrue
+EditorRightTextLimitLineWidth=I1
+ColorsText=C-1
+ColorsBackground=C-16777216
+Colors_M_Keywords=C-16746241
+Colors_M_Comments=C-16724992
+Colors_M_Strings=C-7117861
+Colors_M_UnterminatedStrings=C-2797997
+Colors_M_SystemCommands=C-4210944
+Colors_M_Errors=C-2797997
+Colors_HTML_HTMLLinks=C-10592257
+Colors_M_Warnings=C-27648
+ColorsMLintAutoFixBackground=C-9332736
+Editor.VariableHighlighting.Color=C-10526836
+Editor.NonlocalVariableHighlighting.TextColor=C-16735351
+Editorhighlight-lines=C-15789056
+Editorhighlight-caret-row-boolean-color=C-16763615
+EditorRightTextLimitLineColor=C-5723992
+Color_CmdWinWarnings=C-1208813
+Color_CmdWinErrors=C-2797997


### PR DESCRIPTION
All colors are a close equivalent to the default scheme.

![DarkMATLAB Screenshot 1](https://user-images.githubusercontent.com/40567154/144464847-1cb928a7-fa82-4e7c-aaf4-7f93bad0f322.png)

![DarkMATLAB Screenshot 2](https://user-images.githubusercontent.com/40567154/144464858-4472987c-6096-4712-8693-49171332d9c5.png)


